### PR TITLE
add csv->xml conversion script

### DIFF
--- a/Scripts/alarm_csv2xml.py
+++ b/Scripts/alarm_csv2xml.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# coding: utf-8
+import csv
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+import click
+
+@click.command()
+@click.option('-i', '--infile', prompt='specify name of csv file', required=True,
+              type=str, help='Name of CSV input file.')
+@click.option('-o', '--outfile', default=None, required=False, type=str,
+              help='Name of the XML output file. Derived from name of infile if unspecified.')
+@click.option('-c', '--cname', prompt='specify name of the config', required=True,
+              type=str, help='Name of the config to set inside the XML.')
+def csvtoxml(infile, outfile, cname):
+    """ convert CSV to XML suitable for Phoebus """
+    config = ET.Element('config')
+    config.set('name', cname)
+
+    with open(infile, 'r', encoding='utf-8-sig') as fh:
+        content = csv.DictReader(fh)
+        stack = []
+        stack.append(config)
+        level = 0
+        for row in content:
+            row.update((k, v.strip()) for k, v in row.items())
+            if row['#Indent']:
+                level = int(row['#Indent'])
+                while len(stack) > level + 1:
+                    stack.pop()
+                sel = ET.SubElement(stack[level], 'component')
+                sel.set('name', row['Branch'])
+                stack.append(sel)
+            else:
+                pv = ET.SubElement(stack[-1], 'pv')
+                pv.set('name', row['PV'])
+                desc = ET.SubElement(pv, 'description')
+                desc.text = row['Description']
+                latch = ET.SubElement(pv, 'latching')
+                latch.text = row['Latch'].capitalize()
+                delay = ET.SubElement(pv, 'delay')
+                delay.text = row['Delay']
+
+        xm = minidom.parseString(ET.tostring(config, encoding='utf-8',
+                                             xml_declaration=True,
+                                             short_empty_elements=True))
+    if outfile is None:
+        outfile = infile.rsplit('.', 1)[0] + '.xml'
+    with open(outfile, 'w', encoding='utf-8') as out:
+        out.write(xm.toprettyxml(indent=" "*3))
+    click.echo(f'Conversion of {infile} complete. See {outfile}')
+
+if __name__ == '__main__':
+    csvtoxml()


### PR DESCRIPTION
This adds a python script to convert CSV alarm spreadsheet to XML config file for Phoebus.

This should generate the same output as the existing two scripts, with more flexibility in providing filenames and config names.
```
$ ./alarm_csv2xml.py --help
Usage: alarm_csv2xml.py [OPTIONS]

  convert CSV to XML suitable for Phoebus

Options:
  -i, --infile TEXT   Name of CSV input file.  [required]
  -o, --outfile TEXT  Name of the XML output file. Derived from name of infile
                      if unspecified.
  -c, --cname TEXT    Name of the config to set inside the XML.  [required]
  --help              Show this message and exit.
```

Below is the output from test conversion on current spreadsheet files:
```
pcds-nalms.git/Spreadsheet [master|…1]$ for f in *; do ../Scripts/alarm_csv2xml.py -i $f -c ${f%.csv}; done
Conversion of GMDXGMD.csv complete. See GMDXGMD.xml
Conversion of RTDSK0Vac.csv complete. See RTDSK0Vac.xml
Conversion of SXR-EBD.csv complete. See SXR-EBD.xml
Conversion of SXR-FEE.csv complete. See SXR-FEE.xml
```
and compare with existing files
```
pcds-nalms.git/Spreadsheet [master|…5]$ for f in *xml; do diff --report-identical-files $f ../XML/KFE/$f; done
2c2
< <config name="GMDXGMD">
---
> <config name="nalms-kfe-GMDXGMD">
2c2
< <config name="RTDSK0Vac">
---
> <config name="nalms-kfe-RTDSK0Vac">
2c2
< <config name="SXR-EBD">
---
> <config name="nalms-SXR-SXR-EBD">
433a434,438
>             <pv name="Test">
>                <description>Test</description>
>                <latching>False</latching>
>                <delay>0</delay>
>              </pv>
2c2
< <config name="SXR-FEE">
---
> <config name="nalms-SXR-SXR-FEE">
```
Note that the difference in config name attribute is intentional here, to demonstrate that this is the only difference. 
I note that the existing SXR-EBD.xml is out of sync with its spreadsheet. A Test pv was added only to the XML.