### PR TITLE
BLD: initial gha job

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,0 +1,24 @@
+name: dummy action
+
+on:
+  pull_request:
+
+jobs:
+  echo-hello:
+    runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        # The following allows for each run step to utilize ~/.bash_profile
+        # for setting up the per-step initial state.
+        # --login: a login shell. Source ~/.bash_profile
+        # -e: exit on first error
+        # -o pipefail: piped processes are important; fail if they fail
+        shell: bash --login -eo pipefail {0}
+
+    steps: 
+    - name: dump github
+      env: 
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
Add a generic job to wake up github actions.  This will replaced later, but I remember needing to initialize GHA before it runs in pull requests.