### PR TITLE
Adding untracked XML files

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -43,7 +43,7 @@ jobs:
         git config --global user.name github-actions
         git config --global user.email github-actions@github.com
         export PRNUM=$(git log --grep="Merge pull request" --pretty=oneline -1 | sed -En "s/.*#([[:digit:]]+).*/\1/p")
-	git add XML/
+        git add XML/
         git commit -am "CI/MNT: convert csv to xml from PR# $PRNUM"
         ls -R XML/
         git push

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -43,6 +43,7 @@ jobs:
         git config --global user.name github-actions
         git config --global user.email github-actions@github.com
         export PRNUM=$(git log --grep="Merge pull request" --pretty=oneline -1 | sed -En "s/.*#([[:digit:]]+).*/\1/p")
+	git add XML/
         git commit -am "CI/MNT: convert csv to xml from PR# $PRNUM"
         ls -R XML/
         git push


### PR DESCRIPTION
#103, https://github.com/pcdshub/pcds-nalms/actions/runs/12205014689, failed because it createsa new configuration, leading to the generated xml file being untracked. 

In "push to main" in the workflow, git commit -a is used, which adds all tracked files but not untracked files. I couldn't find a way to add untracked files in git commit, so I just added XML/ before. 