### PR TITLE
Daff

### DIFF
--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.head_ref }}


### PR DESCRIPTION
Meant to close #33 

Adding a new github workflow for pull requests that change anything in the Spreadsheet directory which will

- install daff
- Posts a comment to the pull request with the diff produced by daff (without color unfortunately)
- Update the same comment when retriggered instead of making a new one

Gitea has this https://github.com/go-gitea/gitea/pull/14661, but I couldn't find a way to modify how github displays diffs.

I had to make this trigger on pull_request_target for write permissions to the pull request, so it won't run in this pull request. You can see it working in a pull request between branches of my fork https://github.com/KaushikMalapati/pcds-nalms/pull/2. 

 I believe it will work here, so to test it after review we could either
- Merge into master open another pull request with changes to a csv, check it's working, and close the pull request
- Try the same thing but merge into a new branch, and then merge that branch into master if everything works. 