### PR TITLE
WIP/BLD: push xml changes via deploy key

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
     - name: install dev-requirements
       run: | 
         pip install --upgrade pip


### PR DESCRIPTION
Set up standard xml conversion/deployment workflow to use a deploy key.  This is set up in conjunction with additional branch protections on this repository

This is something of an experiment.  I'm trying to get behavior that combines:
* applying branch protections (required reviews, checks)
* ability for gha to push autogenerated xml without checks

The conceit here is that I can give github actions a deploy key / secret and add that as a bypass to the ruleset.  Once this is merged we'll see for sure

Based on discussions and examples below:
* https://github.com/orgs/community/discussions/25305#discussioncomment-10728028
* https://github.com/sbellone/release-workflow-example/blob/main/.github/workflows/release.yml