### PR TITLE
WIP/BLD: daff perms

### DIFF
--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -1,7 +1,7 @@
 name: Comment Diff
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'Spreadsheet/**'
 
@@ -50,7 +50,6 @@ jobs:
         # set as env var to handle escaping
         DIFF_OUTPUT: ${{ steps.make_diff.outputs.DIFF_OUTPUT }}
       with:
-        github-token: ${{ secrets.COMMENT_TOKEN }}
         script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -1,7 +1,7 @@
 name: Comment Diff
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'Spreadsheet/**'
 
@@ -43,17 +43,12 @@ jobs:
         cat ${{ runner.temp }}/diff.txt >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
 
-    - name: make comment
-      id: make_comment
-      uses: actions/github-script@v7
-      env:
-        # set as env var to handle escaping
-        DIFF_OUTPUT: ${{ steps.make_diff.outputs.DIFF_OUTPUT }}
+    - name: Save PR number
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/NR
+
+    - uses: actions/upload-artifact@v4
       with:
-        script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: process.env.DIFF_OUTPUT
-            })
+        name: diff
+        path: pr/ 

--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -50,6 +50,7 @@ jobs:
         # set as env var to handle escaping
         DIFF_OUTPUT: ${{ steps.make_diff.outputs.DIFF_OUTPUT }}
       with:
+        github-token: ${{ secrets.COMMENT_TOKEN }}
         script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -32,20 +32,13 @@ jobs:
         pip install daff
 
     - name: make diff
-      id: make_diff
       run: |
         daff git csv
         git config set --global diff.daff-csv.command "daff diff --git --output-format html --fragment --context 0"
         git remote add target https://github.com/pcdshub/pcds-nalms.git
         git fetch target
-        git diff target/${{ github.event.pull_request.base.ref }}...HEAD Spreadsheet/ > ${{ runner.temp }}/diff.txt
-        echo 'DIFF_OUTPUT<<EOF' > $GITHUB_OUTPUT
-        cat ${{ runner.temp }}/diff.txt >> $GITHUB_OUTPUT
-        echo 'EOF' >> $GITHUB_OUTPUT
-
-    - name: Save PR number
-      run: |
         mkdir -p ./pr
+        git diff target/${{ github.event.pull_request.base.ref }}...HEAD Spreadsheet/ > pr/diff.txt
         echo ${{ github.event.number }} > ./pr/NR
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/daff.yml
+++ b/.github/workflows/daff.yml
@@ -1,7 +1,7 @@
 name: Comment Diff
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'Spreadsheet/**'
 
@@ -32,15 +32,28 @@ jobs:
         pip install daff
 
     - name: make diff
+      id: make_diff
       run: |
         daff git csv
         git config set --global diff.daff-csv.command "daff diff --git --output-format html --fragment --context 0"
         git remote add target https://github.com/pcdshub/pcds-nalms.git
         git fetch target
         git diff target/${{ github.event.pull_request.base.ref }}...HEAD Spreadsheet/ > ${{ runner.temp }}/diff.txt
+        echo 'DIFF_OUTPUT<<EOF' > $GITHUB_OUTPUT
+        cat ${{ runner.temp }}/diff.txt >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: make comment
-      uses: thollander/actions-comment-pull-request@v3
+      id: make_comment
+      uses: actions/github-script@v7
+      env:
+        # set as env var to handle escaping
+        DIFF_OUTPUT: ${{ steps.make_diff.outputs.DIFF_OUTPUT }}
       with:
-        file-path: ${{ runner.temp }}/diff.txt
-        comment-tag: csvdiff
+        script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.DIFF_OUTPUT
+            })

--- a/.github/workflows/makecomment.yml
+++ b/.github/workflows/makecomment.yml
@@ -41,9 +41,11 @@ jobs:
           script: |
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('./NR'));
+            var diff_text = String(fs.readFileSync('./diff.txt'));
+
             await github.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: 'Everything is OK. Thank you for the PR!'
+              body: diff_text 
             });

--- a/.github/workflows/makecomment.yml
+++ b/.github/workflows/makecomment.yml
@@ -1,0 +1,49 @@
+name: Comment on the pull request
+on:
+  workflow_run:
+    workflows: ["Comment Diff"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "diff"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{ github.workspace }}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.COMMENT_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'Everything is OK. Thank you for the PR!'
+            });

--- a/Spreadsheet/KFE/QRIX-alarms.csv
+++ b/Spreadsheet/KFE/QRIX-alarms.csv
@@ -1,3 +1,2 @@
 ﻿#Indent,Branch,PV,Description,Latch,Delay,Filter,Guidance
 0,QRIX,,,,,,
-,,MR1K1:BEND:RTD:US:1_RBV,TEMPERATURE,,,,


### PR DESCRIPTION
- Transition comment diff workflow to trigger on `pull_request` to lock down write permission tokens
- Try using github-scripts for posting comments

Maybe:
scope out a token with comment permissions and use that for the script specifically