### PR TITLE
Updating github rest api calls

### DIFF
--- a/.github/workflows/makecomment.yml
+++ b/.github/workflows/makecomment.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{ github.event.workflow_run.id }},
@@ -24,7 +24,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "diff"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -43,7 +43,7 @@ jobs:
             var issue_number = Number(fs.readFileSync('./NR'));
             var diff_text = String(fs.readFileSync('./diff.txt'));
 
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,


### PR DESCRIPTION
Error in action - https://github.com/pcdshub/pcds-nalms/actions/runs/12422868845/job/34685382260#step:2:28
```
TypeError: Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:3:38)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35425:12)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35556:12)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1[28](https://github.com/pcdshub/pcds-nalms/actions/runs/12422868845/job/34685382260#step:2:29)8:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
```
Solution found in - https://github.com/actions/github-script/issues/242

> In V5 of this action, we upgraded Octokit and REST methods now need to be referenced by github.rest - https://github.com/actions/github-script#breaking-changes-in-v5

> This should be github.rest.actions.listWorkflowRunArtifacts rather than github.actions.listWorkflowRunArtifacts