### PR TITLE
set latching to True if unspecified

### DIFF
--- a/Scripts/alarm_csv2xml.py
+++ b/Scripts/alarm_csv2xml.py
@@ -32,7 +32,7 @@ def csvtoxml(infile, outfile, cname):
                 desc = ET.SubElement(pv, 'description')
                 desc.text = row['Description']
                 latch = ET.SubElement(pv, 'latching')
-                latch.text = row['Latch'].capitalize()
+                latch.text = row['Latch'].capitalize() if row['Latch'] else "True"
                 delay = ET.SubElement(pv, 'delay')
                 delay.text = row['Delay']
                 if 'Filter' in row and row['Filter']:


### PR DESCRIPTION
Meant to close #39

I thought the change I previously made to phoebus would have done this, but I did not try it on the self-closing tags that our xmls use if the csv value is not provided, I think because of the short_empty_elements in https://github.com/KaushikMalapati/pcds-nalms/blob/3dc96c817de3ab283c8b33ba0319681919317574/Scripts/alarm_csv2xml.py#L45-L47

I think latching by default is the expected behavior. Non-latching alarms seem not very useful to me at least, but alarms can still be set not to latch explicitly. 